### PR TITLE
add toString to Node interface as a required function

### DIFF
--- a/src/cs601/graph/Node.java
+++ b/src/cs601/graph/Node.java
@@ -28,4 +28,7 @@ public interface Node<ID extends Comparable> extends Comparable<Node<ID>> {
 	 *  are no nodes. This makes it easy to implement many of the algorithms.
 	 */
 	public Iterable<ID> edges();
+
+	/** Return the node's name as a String */
+	public String toString();
 }


### PR DESCRIPTION
When we test `getAllReachableNodes`, it returns a List of Node and attaches to a String.
If `Node#toString` is not implemented, the string will look like a array of pointers instead of a array of nodes' names.
So it should be a required function in interface Node.
